### PR TITLE
Hotfix/scroll to top

### DIFF
--- a/app/[lang]/components/HamburgerMenu.tsx
+++ b/app/[lang]/components/HamburgerMenu.tsx
@@ -83,9 +83,6 @@ const HamburgerMenu = ({
             {t("contact")}
           </Link>
         </li>
-        <li className="py-5">
-          <ThemeSwitcher />
-        </li>
       </ul>
     </div>
   );

--- a/app/[lang]/tournois/ScrollToTopButton.tsx
+++ b/app/[lang]/tournois/ScrollToTopButton.tsx
@@ -31,7 +31,7 @@ const ScrollToTopButton = () => {
 
   const scrollToTopButtonClass = isLgScreen
     ? "absolute bottom-0 right-3 p-10"
-    : "fixed top-20 right-3";
+    : "fixed bottom-20 right-3 py-10";
 
   return (
     <button


### PR DESCRIPTION
- scroll to top on mobile screens has been repositioned. It is still hidden behind the map as a dirty hack
- removed theme switch from hamburger menu