### PR TITLE
tournament date filter

### DIFF
--- a/src/app/[locale]/tournaments/page.tsx
+++ b/src/app/[locale]/tournaments/page.tsx
@@ -34,6 +34,11 @@ const getTournaments = async () => {
           },
         },
         {
+          $match: {
+            status: { $ne: "completed" }
+          },
+        },
+        {
           $sort: {
             dateParts: 1,
           },


### PR DESCRIPTION
tournament data is filtered to only include data where 'status' is not 'completed'. Historic data does not have geolocation and many other field data, which was causing a TypeError.