### PR TITLE
hamburger close on footer item click

### DIFF
--- a/src/app/[locale]/components/Footer.tsx
+++ b/src/app/[locale]/components/Footer.tsx
@@ -5,10 +5,13 @@ import { FaGithub, FaRegEnvelope } from "react-icons/fa";
 
 import { Link, usePathname } from "@/utils/navigation";
 
+import { useSetAtom } from "jotai";
+import { burgerMenuIsOpenAtom } from "@/atoms";
 import ThemeSwitcher from "./ThemeSwitcher";
 
 export default function Footer() {
   const t = useTranslations("Footer");
+  const setBurgerMenuIsOpen = useSetAtom(burgerMenuIsOpenAtom);
   const pathname = usePathname();
 
   return (
@@ -16,7 +19,7 @@ export default function Footer() {
       className="fixed bottom-0 z-30 flex h-12 w-[100vw] flex-col items-center justify-center justify-items-center bg-primary-600 px-5 py-2 text-white dark:bg-gray-700"
       data-test="footer"
     >
-      <div className="flex items-center py-2 hover:[&_a]:opacity-80">
+      <div className="flex items-center py-2 hover:[&_a]:opacity-80" onClick={() => setBurgerMenuIsOpen(false)}>
         <a
           href="https://github.com/TheRealOwenRees/echecsfrance"
           target="_blank"

--- a/src/app/[locale]/components/HamburgerMenu.tsx
+++ b/src/app/[locale]/components/HamburgerMenu.tsx
@@ -1,5 +1,3 @@
-import { Dispatch, RefObject, SetStateAction, useRef, useState } from "react";
-
 import { useAtom } from "jotai";
 import { useTranslations } from "next-intl";
 import { twMerge } from "tailwind-merge";


### PR DESCRIPTION
- clicking on a footer item now closes the hamburger menu. Before this fix, clicking on the mail icon would leave the menu open, not allowing the new page to be visible.